### PR TITLE
Replace CR & CRLF with LF on csv data load

### DIFF
--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -11,6 +11,9 @@ function init_table(options) {
 
   $.when($.get(csv_path)).then(
     function(data){
+
+      data = data.replace(/[\r|\r\n]/g, "\n");
+      
       var csv_data = $.csv.toArrays(data, csv_options);
 
       var table_head = "<thead><tr>";


### PR DESCRIPTION
Small addition to csv data load to fix the line breaks that some unfriendly apps or OSes may produce (e.g. Excel on OS X). 

Tested, does not break anything. Should be pretty straight forward.