### PR TITLE
Fixed issue when CSV data wasn't properly escaped in HTML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd csv-to-html-table
 ##### Custom formatting
 If you want to do custom formatting for one or more column, you can pass in an array of arrays containing the index of the column and a custom function for formatting it. You can pass in multiple formatters and they will be executed in order.
 
-The custom functions must take in one parameter (the value in the cell) and return a string:
+The custom functions must take in one parameter (the value in the cell) and return a HTML string:
 
 Example:
 
@@ -68,6 +68,9 @@ Example:
   });
 </script>
 ```
+
+Note that you should take care about HTML escaping to avoid [XSS](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)) or broken layout.
+jQuery has a nice function [text()](https://api.jquery.com/text/) which safely escapes HTML from value.
 
 #### 4. Run it
 

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -9,6 +9,13 @@ CsvToHtmlTable = {
         var csv_options = options.csv_options || {};
         var datatables_options = options.datatables_options || {};
         var custom_formatting = options.custom_formatting || [];
+        var customTemplates = {};
+        $.each(custom_formatting, function (i, v) {
+            var colIdx = v[0];
+            var func = v[1];
+            customTemplates[colIdx] = func;
+        });
+
         var $table = $("<table class='table table-striped table-condensed' id='" + el + "-table'></table>");
         var $containerElement = $("#" + el);
         $containerElement.empty().append($table);
@@ -29,18 +36,13 @@ CsvToHtmlTable = {
 
                 for (var rowIdx = 1; rowIdx < csvData.length; rowIdx++) {
                     var row_html = "<tr>";
-
-                    //takes in an array of column index and function pairs
-                    if (custom_formatting != []) {
-                        $.each(custom_formatting, function (i, v) {
-                            var colIdx = v[0];
-                            var func = v[1];
-                            csvData[rowIdx][colIdx] = func(csvData[rowIdx][colIdx]);
-                        })
-                    }
-
                     for (var colIdx = 0; colIdx < csvData[rowIdx].length; colIdx++) {
-                        row_html += "<td>" + csvData[rowIdx][colIdx] + "</td>";
+                        var cellTemplateFunc = customTemplates[colIdx];
+                        if (cellTemplateFunc) {
+                            row_html += "<td>" + cellTemplateFunc(csvData[rowIdx][colIdx]) + "</td>";
+                        } else {
+                            row_html += "<td>" + csvData[rowIdx][colIdx] + "</td>";
+                        }
                     }
 
                     row_html += "</tr>";

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -35,18 +35,18 @@ CsvToHtmlTable = {
                 var $tableBody = $("<tbody></tbody>");
 
                 for (var rowIdx = 1; rowIdx < csvData.length; rowIdx++) {
-                    var row_html = "<tr>";
+                    var $tableBodyRow = $("<tr></tr>");
                     for (var colIdx = 0; colIdx < csvData[rowIdx].length; colIdx++) {
+                        var $tableBodyRowTd = $("<td></td>");
                         var cellTemplateFunc = customTemplates[colIdx];
                         if (cellTemplateFunc) {
-                            row_html += "<td>" + cellTemplateFunc(csvData[rowIdx][colIdx]) + "</td>";
+                            $tableBodyRowTd.html(cellTemplateFunc(csvData[rowIdx][colIdx]));
                         } else {
-                            row_html += "<td>" + csvData[rowIdx][colIdx] + "</td>";
+                            $tableBodyRowTd.text(csvData[rowIdx][colIdx]);
                         }
+                        $tableBodyRow.append($tableBodyRowTd);
+                        $tableBody.append($tableBodyRow);
                     }
-
-                    row_html += "</tr>";
-                    $tableBody.append(row_html);
                 }
                 $table.append($tableBody);
 

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -10,7 +10,8 @@ CsvToHtmlTable = {
         var datatables_options = options.datatables_options || {};
         var custom_formatting = options.custom_formatting || [];
         var $table = $("<table class='table table-striped table-condensed' id='" + el + "-table'></table>");
-        $("#" + el).empty().append($table);
+        var $containerElement = $("#" + el);
+        $containerElement.empty().append($table);
 
         $.when($.get(csv_path)).then(
             function (data) {
@@ -51,7 +52,7 @@ CsvToHtmlTable = {
                 $table.DataTable(datatables_options);
 
                 if (allow_download) {
-                    $("#" + el).append("<p><a class='btn btn-info' href='" + csv_path + "'><i class='glyphicon glyphicon-download'></i> Download as CSV</a></p>");
+                    $containerElement.append("<p><a class='btn btn-info' href='" + csv_path + "'><i class='glyphicon glyphicon-download'></i> Download as CSV</a></p>");
                 }
             });
     }

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -2,55 +2,55 @@ var CsvToHtmlTable = CsvToHtmlTable || {};
 
 CsvToHtmlTable = {
     init: function (options) {
+        options = options || {};
+        var csv_path = options.csv_path || "";
+        var el = options.element || "table-container";
+        var allow_download = options.allow_download || false;
+        var csv_options = options.csv_options || {};
+        var datatables_options = options.datatables_options || {};
+        var custom_formatting = options.custom_formatting || [];
 
-      options = options || {};
-      var csv_path = options.csv_path || "";
-      var el = options.element || "table-container";
-      var allow_download = options.allow_download || false;
-      var csv_options = options.csv_options || {};
-      var datatables_options = options.datatables_options || {};
-      var custom_formatting = options.custom_formatting || [];
+        $("#" + el).html("<table class='table table-striped table-condensed' id='" + el + "-table'></table>");
 
-      $("#" + el).html("<table class='table table-striped table-condensed' id='" + el + "-table'></table>");
+        $.when($.get(csv_path)).then(
+            function (data) {
+                var csv_data = $.csv.toArrays(data, csv_options);
 
-      $.when($.get(csv_path)).then(
-        function(data){      
-          var csv_data = $.csv.toArrays(data, csv_options);
-          
-          var table_head = "<thead><tr>";
+                var table_head = "<thead><tr>";
 
-          for (head_id = 0; head_id < csv_data[0].length; head_id++) { 
-            table_head += "<th>" + csv_data[0][head_id] + "</th>";
-          }
+                for (head_id = 0; head_id < csv_data[0].length; head_id++) {
+                    table_head += "<th>" + csv_data[0][head_id] + "</th>";
+                }
 
-          table_head += "</tr></thead>";
-          $('#' + el + '-table').append(table_head);
-          $('#' + el + '-table').append("<tbody></tbody>");
+                table_head += "</tr></thead>";
+                $('#' + el + '-table').append(table_head);
+                $('#' + el + '-table').append("<tbody></tbody>");
 
-          for (row_id = 1; row_id < csv_data.length; row_id++) { 
-            var row_html = "<tr>";
+                for (row_id = 1; row_id < csv_data.length; row_id++) {
+                    var row_html = "<tr>";
 
-            //takes in an array of column index and function pairs
-            if (custom_formatting != []) {
-              $.each(custom_formatting, function(i, v){
-                var col_idx = v[0]
-                var func = v[1];
-                csv_data[row_id][col_idx]= func(csv_data[row_id][col_idx]);
-              })
-            }
+                    //takes in an array of column index and function pairs
+                    if (custom_formatting != []) {
+                        $.each(custom_formatting, function (i, v) {
+                            var col_idx = v[0];
+                            var func = v[1];
+                            csv_data[row_id][col_idx] = func(csv_data[row_id][col_idx]);
+                        })
+                    }
 
-            for (col_id = 0; col_id < csv_data[row_id].length; col_id++) { 
-              row_html += "<td>" + csv_data[row_id][col_id] + "</td>";
-            }
-              
-            row_html += "</tr>";
-            $('#' + el + '-table tbody').append(row_html);
-          }
+                    for (col_id = 0; col_id < csv_data[row_id].length; col_id++) {
+                        row_html += "<td>" + csv_data[row_id][col_id] + "</td>";
+                    }
 
-          $('#' + el + '-table').DataTable(datatables_options);
+                    row_html += "</tr>";
+                    $('#' + el + '-table tbody').append(row_html);
+                }
 
-          if (allow_download)
-            $("#" + el).append("<p><a class='btn btn-info' href='" + csv_path + "'><i class='glyphicon glyphicon-download'></i> Download as CSV</a></p>");
-        });
+                $('#' + el + '-table').DataTable(datatables_options);
+
+                if (allow_download) {
+                    $("#" + el).append("<p><a class='btn btn-info' href='" + csv_path + "'><i class='glyphicon glyphicon-download'></i> Download as CSV</a></p>");
+                }
+            });
     }
-}
+};

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -14,32 +14,33 @@ CsvToHtmlTable = {
 
         $.when($.get(csv_path)).then(
             function (data) {
-                var csv_data = $.csv.toArrays(data, csv_options);
+                var csvData = $.csv.toArrays(data, csv_options);
 
-                var table_head = "<thead><tr>";
+                var tableHead = "<thead><tr>";
 
-                for (head_id = 0; head_id < csv_data[0].length; head_id++) {
-                    table_head += "<th>" + csv_data[0][head_id] + "</th>";
+                var csvHeaderRow = csvData[0];
+                for (var headerIdx = 0; headerIdx < csvHeaderRow.length; headerIdx++) {
+                    tableHead += "<th>" + csvHeaderRow[headerIdx] + "</th>";
                 }
 
-                table_head += "</tr></thead>";
-                $('#' + el + '-table').append(table_head);
+                tableHead += "</tr></thead>";
+                $('#' + el + '-table').append(tableHead);
                 $('#' + el + '-table').append("<tbody></tbody>");
 
-                for (row_id = 1; row_id < csv_data.length; row_id++) {
+                for (var rowIdx = 1; rowIdx < csvData.length; rowIdx++) {
                     var row_html = "<tr>";
 
                     //takes in an array of column index and function pairs
                     if (custom_formatting != []) {
                         $.each(custom_formatting, function (i, v) {
-                            var col_idx = v[0];
+                            var colIdx = v[0];
                             var func = v[1];
-                            csv_data[row_id][col_idx] = func(csv_data[row_id][col_idx]);
+                            csvData[rowIdx][colIdx] = func(csvData[rowIdx][colIdx]);
                         })
                     }
 
-                    for (col_id = 0; col_id < csv_data[row_id].length; col_id++) {
-                        row_html += "<td>" + csv_data[row_id][col_id] + "</td>";
+                    for (var colIdx = 0; colIdx < csvData[rowIdx].length; colIdx++) {
+                        row_html += "<td>" + csvData[rowIdx][colIdx] + "</td>";
                     }
 
                     row_html += "</tr>";

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -9,8 +9,8 @@ CsvToHtmlTable = {
         var csv_options = options.csv_options || {};
         var datatables_options = options.datatables_options || {};
         var custom_formatting = options.custom_formatting || [];
-
-        $("#" + el).html("<table class='table table-striped table-condensed' id='" + el + "-table'></table>");
+        var $table = $("<table class='table table-striped table-condensed' id='" + el + "-table'></table>");
+        $("#" + el).empty().append($table);
 
         $.when($.get(csv_path)).then(
             function (data) {
@@ -24,8 +24,9 @@ CsvToHtmlTable = {
                 }
 
                 tableHead += "</tr></thead>";
-                $('#' + el + '-table').append(tableHead);
-                $('#' + el + '-table').append("<tbody></tbody>");
+                $table.append(tableHead);
+                var $tableBody = $("<tbody></tbody>");
+                $table.append($tableBody);
 
                 for (var rowIdx = 1; rowIdx < csvData.length; rowIdx++) {
                     var row_html = "<tr>";
@@ -44,10 +45,10 @@ CsvToHtmlTable = {
                     }
 
                     row_html += "</tr>";
-                    $('#' + el + '-table tbody').append(row_html);
+                    $tableBody.append(row_html);
                 }
 
-                $('#' + el + '-table').DataTable(datatables_options);
+                $table.DataTable(datatables_options);
 
                 if (allow_download) {
                     $("#" + el).append("<p><a class='btn btn-info' href='" + csv_path + "'><i class='glyphicon glyphicon-download'></i> Download as CSV</a></p>");

--- a/js/csv_to_html_table.js
+++ b/js/csv_to_html_table.js
@@ -16,18 +16,16 @@ CsvToHtmlTable = {
         $.when($.get(csv_path)).then(
             function (data) {
                 var csvData = $.csv.toArrays(data, csv_options);
-
-                var tableHead = "<thead><tr>";
-
+                var $tableHead = $("<thead></thead>");
                 var csvHeaderRow = csvData[0];
+                var $tableHeadRow = $("<tr></tr>");
                 for (var headerIdx = 0; headerIdx < csvHeaderRow.length; headerIdx++) {
-                    tableHead += "<th>" + csvHeaderRow[headerIdx] + "</th>";
+                    $tableHeadRow.append($("<th></th>").text(csvHeaderRow[headerIdx]));
                 }
+                $tableHead.append($tableHeadRow);
 
-                tableHead += "</tr></thead>";
-                $table.append(tableHead);
+                $table.append($tableHead);
                 var $tableBody = $("<tbody></tbody>");
-                $table.append($tableBody);
 
                 for (var rowIdx = 1; rowIdx < csvData.length; rowIdx++) {
                     var row_html = "<tr>";
@@ -48,6 +46,7 @@ CsvToHtmlTable = {
                     row_html += "</tr>";
                     $tableBody.append(row_html);
                 }
+                $table.append($tableBody);
 
                 $table.DataTable(datatables_options);
 


### PR DESCRIPTION
Each cell in CSV can contain special characters like `<`, `>` which can be considered by browser as a begging of HTML tag. This can broke layout and even can be used by a hacker for https://www.owasp.org/index.php/Cross-site_Scripting_(XSS) 

1. Improved performance by reusing jQuery object instead of getting it from DOM by selector each time.
2. Use jQuery methods instead of manual HTML concatenation and manipulation.
3. Escape html while rendering cell content